### PR TITLE
[WIP] Debug the registration of the TrackerLayer's clickCallbacks...

### DIFF
--- a/src/layers/TrackerLayer.js
+++ b/src/layers/TrackerLayer.js
@@ -310,8 +310,10 @@ class TrackerLayer extends Layer {
    *   the layer instance and the click event.
    */
   onClick(callback) {
+    console.log('eva', 'TrackerLayer', this, 'onClick', callback);
     if (typeof callback === 'function') {
       if (!this.clickCallbacks.includes(callback)) {
+        console.log('eva', 'TrackerLayer', this, 'onClick', 'push', 'clickCallbacks', callback);
         this.clickCallbacks.push(callback);
       }
     } else {
@@ -326,9 +328,11 @@ class TrackerLayer extends Layer {
    *   the layer instance and the click event.
    */
   unClick(callback) {
+    console.log('eva', 'TrackerLayer', this, 'unClick', callback);
     if (typeof callback === 'function') {
       const idx = this.clickCallbacks.indexOf(callback);
       if (idx >= -1) {
+        console.log('eva', 'TrackerLayer', this, 'onClick', 'splice', 'clickCallbacks', callback);
         this.clickCallbacks.splice(idx, 1);
       }
     }

--- a/src/layers/TrajservLayer.js
+++ b/src/layers/TrajservLayer.js
@@ -203,6 +203,7 @@ class TrajservLayer extends TrackerLayer {
     this.showVehicleTraj =
       options.showVehicleTraj !== undefined ? options.showVehicleTraj : true;
     this.apiKey = options.apiKey;
+    console.log('eva', 'TrajservLayer.js', this, 'constructor', this.apiKey, options.apiKey);
     this.delayDisplay = options.delayDisplay || 300000;
     this.requestIntervalSeconds = 3;
     this.useDelayStyle = options.useDelayStyle || false;
@@ -267,6 +268,7 @@ class TrajservLayer extends TrackerLayer {
     this.olEventsKeys = [
       ...this.olEventsKeys,
       this.map.on('singleclick', (e) => {
+        console.log('eva', 'TrajservLayer', this, 'singleclick', this.clickCallbacks);
         if (!this.clickCallbacks.length) {
           return;
         }
@@ -283,6 +285,7 @@ class TrajservLayer extends TrackerLayer {
           if (features.length) {
             this.selectedVehicleId = features[0].get('id');
             this.journeyId = features[0].get('journeyIdentifier');
+            console.log('eva', 'TrajservLayer', this, 'singleclick', 'fetchTrajectoryStations', features);;
             this.fetchTrajectoryStations(this.selectedVehicleId).then((r) => {
               this.clickCallbacks.forEach((c) => c(r, this, e));
             });
@@ -522,6 +525,7 @@ class TrajservLayer extends TrackerLayer {
       key: this.apiKey,
       // toff: this.currTime.getTime() / 1000,
     };
+    console.log('eva', 'TrajservLayer.js', this, 'getUrlParams', params);
 
     // Allow to load only differences between the last request,
     // but currently the Tracker render method doesn't manage to render only diff.
@@ -561,6 +565,7 @@ class TrajservLayer extends TrackerLayer {
    * @private
    */
   updateTrajectories() {
+    console.log('eva', 'TrajservLayer.js', this, 'fetchTrajectories');
     this.fetchTrajectories(
       `${this.url}/trajectory_collection?${this.getUrlParams({
         attr_det: 1,


### PR DESCRIPTION
when loading trafimage-maps topics.
Searching the bug why the clickCallbacks of the punctuality layer aren't defined anymore
after adding the internal topics

# How to

<!--  Please provide a test link and quick description how to see the change -->
see https://github.com/geops/trafimage-maps/pull/675

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
