### PR TITLE
Deprecate repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # React Transit
 
+![No longer maintained](https://img.shields.io/badge/Maintenance-OFF-red.svg)
 [![npm](https://img.shields.io/npm/v/react-transit.svg?style=flat-square)](https://www.npmjs.com/package/react-transit)
 [![build](https://github.com/geops/react-transit/workflows/main/badge.svg)](https://github.com/geops/react-transit/actions?query=workflow%3Amain)
 [![dependabot](https://badgen.net/dependabot/geops/react-transit/?icon=dependabot)](https://github.com/marketplace/dependabot-preview)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/3906ac5a-46f8-4de3-ae19-4be77060a368/deploy-status)](https://app.netlify.com/sites/react-transit/deploys)
 
+## [DEPRECATED] This repository is no longer maintained
+This library is no longer maintained as it was integrated into react-spatial. Please consider using [react-spatial](https://github.com/geops/react-spatial) instead.
+
+## About
 This library provides React components to visualize real-time geographical information based on [OpenLayers](https://openlayers.org/).
 
 Documentation and examples at https://react-transit.geops.de.


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Deprecates this repository based on https://github.com/ModusCreateOrg/labs/wiki/Deprecating-a-repository

Please, have a look at the [README.md](https://github.com/geops/react-transit/tree/gevos/deprecate) to test.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] Labels applied. if it's a release? a hotfix?
